### PR TITLE
feat: add useClickOutside hook

### DIFF
--- a/.yarn/versions/50436951.yml
+++ b/.yarn/versions/50436951.yml
@@ -1,0 +1,2 @@
+releases:
+  react-hooks-shareable: minor

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@ import { ResizeObserver } from '@juggle/resize-observer'
 
 export * from './useAnalytics'
 export * from './useBoolean'
+export * from './useClickOutside'
 export * from './useDeferredTrigger'
 export * from './useDraggable'
 export * from './useFocusDetection'

--- a/src/useClickOutside.ts
+++ b/src/useClickOutside.ts
@@ -1,0 +1,50 @@
+import { useRef, useEffect } from 'react'
+
+type Callback = (e: PointerEvent) => void
+
+/**
+ * A hook that fires a callback when a click (pointerdown) was registered outside
+ * of a component. Outside is defined as outside of your react tree, which means
+ * that this works with portals.
+ *
+ * Examples:
+ *
+ * ```tsx
+ * const OutsideTest = () => {
+ *   const handler = useClickOutside(e => {
+ *     console.log('Outside')
+ *   })
+ *
+ *   return (
+ *     <div onPointerDown={handler}>
+ *       <span>Clicks here is inside</span>
+ *       {ReactDOM.createPortal(
+ *         <span>Clicks here are also inside</span>,
+ *         portalContainer
+ *       )}
+ *     </div>
+ *   )
+ * }
+ * ```
+ */
+export const useClickOutside = (callback: Callback): Callback => {
+  const inside = useRef(false)
+
+  const handleClick: Callback = () => {
+    inside.current = true
+  }
+
+  useEffect(() => {
+    const listener: Callback = e => {
+      if (!inside.current) {
+        callback(e)
+      }
+      inside.current = false
+    }
+
+    document.addEventListener('pointerdown', listener)
+    return () => document.removeEventListener('pointerdown', listener)
+  })
+
+  return handleClick
+}


### PR DESCRIPTION
A hook that fires a callback when a click (pointerdown) was registered outside
of a component. Outside is defined as outside of your react tree, which means
that this works with portals.

Examples:

```tsx
const OutsideTest = () => {
  const handler = useClickOutside(e => {
    console.log('Outside')
  })

  return (
    <div onPointerDown={handler}>
      <span>Clicks here is inside</span>
      {ReactDOM.createPortal(
        <span>Clicks here are also inside</span>,
        portalContainer
      )}
    </div>
  )
}
```