### PR TITLE
fix: useLocalStorage return type

### DIFF
--- a/src/useLocalStorage.ts
+++ b/src/useLocalStorage.ts
@@ -33,14 +33,16 @@ export const getLocalStorage = () => {
   })
 }
 
-export function useLocalStorage<T = undefined>(
+type Maybe<T> = T | null
+
+export function useLocalStorage<T = string>(
   key: string
-): readonly [T | undefined, (value: T) => void] {
+): readonly [Maybe<T>, (value: T) => void] {
   const storage = getLocalStorage()
 
   // State to store our value
   // Pass initial state function to useState so logic is only executed once
-  const [storedValue, setStoredValue] = useState<T>(() => storage[key])
+  const [storedValue, setStoredValue] = useState<Maybe<T>>(() => storage[key])
 
   // Return a wrapped version of useState's setter function that ...
   // ... persists the new value to localStorage.


### PR DESCRIPTION
If there is no value in localStorage it will not return `undefined`, it will return `null`.

Also change default return type to string, instead of `undefined` since it just can't have that value.
Even if you try to explicitly set a localStorage value to `undefined` it will convert it to the string "undefined".