### PR TITLE
fix: correct types for useSynchronizedAnimation

### DIFF
--- a/src/useSynchronizedAnimation.ts
+++ b/src/useSynchronizedAnimation.ts
@@ -1,11 +1,14 @@
 import { useLayoutEffect, useRef } from 'react'
 
-export const useSynchronizedAnimation = (options?: GetAnimationsOptions) => {
-  const ref = useRef<HTMLElement>()
+export const useSynchronizedAnimation = <E extends HTMLElement>(
+  options?: GetAnimationsOptions
+) => {
+  const ref = useRef<E | null>(null)
   useLayoutEffect(() => {
+    const currentTime = document.timeline?.currentTime ?? 0
     ref.current
       ?.getAnimations(options)
-      .forEach(a => (a.currentTime = document.timeline.currentTime))
+      .forEach(a => (a.currentTime = currentTime))
   }, [options])
   return ref
 }


### PR DESCRIPTION
### Describe your changes

If we don't default to null it is not usable with styled-components.
Also add template types similar to `useRef`.

### Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have verified that the code builds perfectly fine on my local system
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have verified that my code follows the style already available in the repository
- [ ] I have made corresponding changes to the documentation
