### PR TITLE
fix: clear old timers in useDeferredTrigger

### DIFF
--- a/src/useDeferredTrigger.ts
+++ b/src/useDeferredTrigger.ts
@@ -75,6 +75,7 @@ export const useDeferredTrigger = (
           // We need to wait at least a certain amount of time before
           // applying the delay. This can always be canceled by an update
           // that re-triggers this effect (as the timeout can be cleared).
+          clearTimeout(timeoutRef.current)
           timeoutRef.current = window.setTimeout(toggleFlag, scheduledDelay)
         }
       }


### PR DESCRIPTION
With React 18, useEffect can run twice on mount in
strict mode (during development), which would lead
to a spurious timer remaining active. The timer always
needs to be cleared before a new one is set.

### Describe your changes

Please include a summary of the change, a relevant motivation and context.

### Issue ticket number and link

- Fixes #(issue)

### Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [ ] I have verified that the code builds perfectly fine on my local system
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have verified that my code follows the style already available in the repository
- [ ] I have made corresponding changes to the documentation
