### PR TITLE
fix: remove window from timeout methods

### DIFF
--- a/src/useDeferredTrigger.ts
+++ b/src/useDeferredTrigger.ts
@@ -42,7 +42,7 @@ export const useDeferredTrigger = (
   { delay = 100, minDuration = 400, base = false }: IDeferredTriggerOptions = {}
 ) => {
   const [deferredFlag, setDeferredFlag] = useState(base)
-  const timeoutRef = useRef<number>()
+  const timeoutRef = useRef<ReturnType<typeof setTimeout>>()
   const lastActive = useRef<number>()
 
   useEffect(() => {
@@ -75,15 +75,16 @@ export const useDeferredTrigger = (
           // We need to wait at least a certain amount of time before
           // applying the delay. This can always be canceled by an update
           // that re-triggers this effect (as the timeout can be cleared).
-          clearTimeout(timeoutRef.current)
-          timeoutRef.current = window.setTimeout(toggleFlag, scheduledDelay)
+          timeoutRef.current = setTimeout(toggleFlag, scheduledDelay)
         }
       }
     } else {
       // The target flag matches the deferred flag,
       // so clear any scheduled changes to it.
-      clearTimeout(timeoutRef.current)
-      timeoutRef.current = undefined
+      if (timeoutRef.current !== undefined) {
+        clearTimeout(timeoutRef.current)
+        timeoutRef.current = undefined
+      }
     }
   }, [flag, deferredFlag, base, delay, minDuration])
 


### PR DESCRIPTION
Mixing window.setTimeout and setTimeout doesn't work when running
tests (in e.g. NodeJS). Instead, fix the possible types.

### Describe your changes

Please include a summary of the change, a relevant motivation and context.

### Issue ticket number and link

- Fixes #(issue)

### Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [ ] I have verified that the code builds perfectly fine on my local system
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have verified that my code follows the style already available in the repository
- [ ] I have made corresponding changes to the documentation
