### PR TITLE
Pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,12 +16,12 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@a37ce9120846195fa4ece8f58b268e6043cb2f26 # v3.7.0
         with:
           fetch-depth: 0
 
       - name: Setup node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3.9.1
         with:
           node-version: '18'
           registry-url: 'https://registry.npmjs.org'
@@ -42,7 +42,7 @@ jobs:
 
       - name: Release
         id: release
-        uses: actions/create-release@v1
+        uses: actions/create-release@0cb9c9b65d5d1901c1f53e5e66eaf4afd303e70e # v1.1.4
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -21,12 +21,12 @@ jobs:
       matrix:
         node-version: ['16', '18']
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@a37ce9120846195fa4ece8f58b268e6043cb2f26 # v3.7.0
         with:
           fetch-depth: 0
 
       - name: Setup node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3.9.1
         with:
           node-version: ${{ matrix.node-version }}
 


### PR DESCRIPTION
This pull request applies the OSSF Scorecard **Pinned-Dependencies** remedy.

It pins the GitHub Actions used in the following workflows to full commit SHAs, keeping the original version as a trailing comment:

- `.github/workflows/publish.yml`
- `.github/workflows/verify.yml`

Renovate recognises the `@<sha> # <version>` format and will keep these pinned actions updated automatically.

See the [OSSF Scorecard guidance](https://github.com/AxisCommunications/github-governance/blob/main/ossf-scorecard/README.md#pinned-dependencies) for details.